### PR TITLE
Add sed command to replace 127.0.0.1

### DIFF
--- a/cloudinit.txt
+++ b/cloudinit.txt
@@ -52,6 +52,7 @@ chmod 777 -R /home/coder/project/openfaas
 # Run VSCode last
 
 sed -ie s/localhost/$IP/g /root/.kube/config
+sed -ie s/127.0.0.1/$IP/g /root/.kube/config
 chmod 777 /root/.kube/config
 
 mkdir -p /root/certs


### PR DESCRIPTION
This commit adds a sed command which replaces 127.0.0.1 by the host ip
in the kube config.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>